### PR TITLE
1014요구사항

### DIFF
--- a/src/Components/Admin/EventAproval.tsx
+++ b/src/Components/Admin/EventAproval.tsx
@@ -8,6 +8,9 @@ import PleaseLogin from "../Login/PleaseLogin";
 import { useAproval } from "../../Hooks/useAproval";
 import { format } from "date-fns";
 import AprovalDetailModal, { AprovalModalData } from "./AprovalDetailModal";
+import ManageTableFiltering, {
+  ManageFilterStatus,
+} from "../Event/Manage/ManageTableFiltering";
 
 interface EventAprovalType {
   content: Array<{
@@ -22,12 +25,11 @@ interface EventAprovalType {
   pageNumber: number;
   totalPages: number;
 }
-
-const fetcher = (page: number) =>
+const fetcher = (page: number, status?: ManageFilterStatus) =>
   fetch(
-    `http://52.79.91.214:8080/admin/events?page=${
-      page - 1
-    }&status=all&sort=registeredAt%2CDESC`,
+    `http://52.79.91.214:8080/admin/events?page=${page - 1}&status=${
+      status || "all"
+    }&sort=registeredAt%2CDESC`,
     {
       method: "GET",
       headers: {
@@ -56,13 +58,14 @@ export const getSlicingText = (text: string, lastIndex: number) => {
 
 // TODO: 관리자 계정이 아닐경우 return
 export default function EventAproval() {
+  const [filterStatus, setFilterStatus] = useState<ManageFilterStatus>("all");
   const [searchParams] = useSearchParams();
   const page = searchParams.get("page") ?? 1;
   const [shouldOpenModal, setShouldOpenModal] = useState(false);
   const [modalData, setModalData] = useState<AprovalModalData | null>(null);
   const { data, isError, refetch } = useQuery<EventAprovalType>({
-    queryKey: ["event-aproval"],
-    queryFn: () => fetcher(+page),
+    queryKey: ["event-aproval", filterStatus],
+    queryFn: () => fetcher(+page, filterStatus),
   });
 
   const {
@@ -103,17 +106,20 @@ export default function EventAproval() {
     <div className="flex-1 w-full flex flex-col p-2">
       <div className="w-full inline-flex gap-3 p-2">
         <button
-          className="border p-2 px-4 rounded-md font-bold text-white bg-green-400"
+          className={`border p-2 px-4 rounded-md font-bold text-white bg-green-400 disabled:bg-green-400/50`}
+          disabled={!checkList.some((ischeck) => ischeck)}
           onClick={() => changeStates("APPROVE")}
         >
-          승인
+          모두승인
         </button>
         <button
-          className="border p-2 px-4 rounded-md font-bold text-white bg-red-400"
+          className="border p-2 px-4 rounded-md font-bold text-white bg-red-400 disabled:bg-red-400/50"
+          disabled={!checkList.some((ischeck) => ischeck)}
           onClick={() => changeStates("REJECT")}
         >
-          반려
+          모두반려
         </button>
+        <ManageTableFiltering setFilterStatus={setFilterStatus} />
       </div>
       <div className="overflow-x-auto">
         <div className="container mx-auto">

--- a/src/Components/Booth/List/BoothNoticeList.tsx
+++ b/src/Components/Booth/List/BoothNoticeList.tsx
@@ -25,9 +25,6 @@ export default function BoothNoticeList() {
       next={fetchNextPage}
       hasMore={hasNextPage}
       loader={<h4 className="text-center my-4">로딩 중...</h4>}
-      endMessage={
-        <p className="text-center font-bold my-4">모든 공지를 불러왔습니다</p>
-      }
       className="w-full max-w-screen-lg h-full p-2 pt-10 mx-auto"
     >
       {

--- a/src/Components/Event/AddEvent.tsx
+++ b/src/Components/Event/AddEvent.tsx
@@ -253,6 +253,7 @@ export default function AddEventPage() {
                 value={eventDetails.location}
               />
               <button
+                type="button"
                 className="mt-7 border shadow-sm rounded-md p-1 w-24"
                 onClick={(e) => {
                   e.preventDefault();

--- a/src/Components/Event/AddEvent.tsx
+++ b/src/Components/Event/AddEvent.tsx
@@ -213,7 +213,10 @@ export default function AddEventPage() {
   }
 
   return (
-    <form className="flex min-h-screen justify-center" onSubmit={onSubmit}>
+    <form
+      className="flex min-h-screen justify-center my-10"
+      onSubmit={onSubmit}
+    >
       {isAddressOpen && (
         <div
           className="fixed flex justify-center items-center top-0 w-full h-full bg-black/20"

--- a/src/Components/Event/EventDetail.tsx
+++ b/src/Components/Event/EventDetail.tsx
@@ -81,8 +81,8 @@ export default function EventDetailPage() {
   const isRecruiting = new Date() < new Date(data.openDate);
 
   return (
-    <div className="flex min-h-screen justify-center" onSubmit={onSubmit}>
-      <div className="w-full max-w-screen-lg shadow-2xl h-full p-2">
+    <div className="flex min-h-screen justify-center my-10" onSubmit={onSubmit}>
+      <div className="w-full max-w-screen-lg shadow-md h-full p-2">
         <BookmarkIcon
           id={eventId}
           isBookmark={false}

--- a/src/Components/Event/EventNoticeList.tsx
+++ b/src/Components/Event/EventNoticeList.tsx
@@ -30,10 +30,7 @@ export default function EventNoticeList() {
       next={fetchNextPage}
       hasMore={hasNextPage}
       loader={<h4 className="text-center my-4">로딩 중...</h4>}
-      endMessage={
-        <p className="text-center font-bold my-4">모든 공지를 불러왔습니다</p>
-      }
-      className="w-full max-w-screen-lg shadow-2xl h-full p-2 pt-10 mx-auto"
+      className="w-full max-w-screen-lg h-screen p-2 pt-10 border-b mx-auto"
     >
       {eventData?.eventManager.id === userId && (
         <AddNotice id={+(id ?? 0)} type="events" refetch={refetch} />

--- a/src/Components/Event/Manage/EventManage.tsx
+++ b/src/Components/Event/Manage/EventManage.tsx
@@ -2,7 +2,10 @@ import BoothAproval from "./BoothAproval";
 
 export default function EventManage() {
   return (
-    <section className="flex min-h-screen justify-center" onSubmit={() => {}}>
+    <section
+      className="flex min-h-screen justify-center my-10"
+      onSubmit={() => {}}
+    >
       <div className="w-full max-w-screen-lg border h-full p-10">
         <div className="flex items-center gap-20 border-b p-7">
           <h2 className="font-extrabold text-4xl">행사 관리</h2>

--- a/src/Components/Event/Manage/ManageTableFiltering.tsx
+++ b/src/Components/Event/Manage/ManageTableFiltering.tsx
@@ -1,0 +1,57 @@
+interface Props {
+  setFilterStatus: (status: ManageFilterStatus) => void;
+}
+
+export type ManageFilterStatus = "waiting" | "approved" | "rejected" | "all";
+
+export default function ManageTableFiltering({ setFilterStatus }: Props) {
+  return (
+    <div className="flex items-center ml-auto gap-5">
+      <label>
+        <input
+          type="radio"
+          name="filtering"
+          value={"all"}
+          defaultChecked
+          onChange={() => {
+            setFilterStatus("all");
+          }}
+        />
+        모두보기
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="filtering"
+          value={"waiting"}
+          onChange={() => {
+            setFilterStatus("waiting");
+          }}
+        />
+        대기 중
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="filtering"
+          value={"rejected"}
+          onChange={() => {
+            setFilterStatus("rejected");
+          }}
+        />
+        반려
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="filtering"
+          value={"approved"}
+          onChange={() => {
+            setFilterStatus("approved");
+          }}
+        />
+        승인
+      </label>
+    </div>
+  );
+}

--- a/src/Components/Event/Manage/ManageTableFiltering.tsx
+++ b/src/Components/Event/Manage/ManageTableFiltering.tsx
@@ -7,7 +7,7 @@ export type ManageFilterStatus = "waiting" | "approved" | "rejected" | "all";
 export default function ManageTableFiltering({ setFilterStatus }: Props) {
   return (
     <div className="flex items-center ml-auto gap-5">
-      <label>
+      <label className="flex items-center gap-1">
         <input
           type="radio"
           name="filtering"
@@ -19,7 +19,7 @@ export default function ManageTableFiltering({ setFilterStatus }: Props) {
         />
         모두보기
       </label>
-      <label>
+      <label className="flex items-center gap-1">
         <input
           type="radio"
           name="filtering"
@@ -30,7 +30,7 @@ export default function ManageTableFiltering({ setFilterStatus }: Props) {
         />
         대기 중
       </label>
-      <label>
+      <label className="flex items-center gap-1">
         <input
           type="radio"
           name="filtering"
@@ -41,7 +41,7 @@ export default function ManageTableFiltering({ setFilterStatus }: Props) {
         />
         반려
       </label>
-      <label>
+      <label className="flex items-center gap-1">
         <input
           type="radio"
           name="filtering"

--- a/src/Components/Layout/RequestLayout.tsx
+++ b/src/Components/Layout/RequestLayout.tsx
@@ -5,7 +5,10 @@ interface Props {
 }
 export default function RequestLayout({ children, header, side }: Props) {
   return (
-    <section className="flex min-h-screen justify-center" onSubmit={() => {}}>
+    <section
+      className="flex min-h-screen justify-center my-10"
+      onSubmit={() => {}}
+    >
       <div className="w-full max-w-screen-lg border h-full p-10">
         <div className="flex items-center gap-20 border-b p-7">
           <h2 className="font-extrabold text-4xl">{header}</h2>

--- a/src/Components/Main/Main.tsx
+++ b/src/Components/Main/Main.tsx
@@ -1,7 +1,10 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import tempBanner from "../Main/Banner/main_banner1.png";
 import tempBannerSmall from "../Main/Banner/main_banner_small.png";
 import ShowEventList from "./ShowEventList";
+import RecentEvent from "./RecentEvent";
+import OngoingEvent from "./OngoingEvent";
+import SoonEndEvent from "./SoonEndEvent";
 
 interface Props {
   state: "main" | "list";
@@ -19,13 +22,9 @@ enum MainListTab {
 
 const listTabs = {
   [MainListTab.popular]: <ShowEventList title="인기있는 부스" eventList={[]} />,
-  [MainListTab.recent]: <ShowEventList title="최근 열린 행사" eventList={[]} />,
-  [MainListTab.recruiting]: (
-    <ShowEventList title="부스 모집 중" eventList={[]} />
-  ),
-  [MainListTab.soonend]: (
-    <ShowEventList title="종료 예정인 행사" eventList={[]} />
-  ),
+  [MainListTab.recent]: <RecentEvent />,
+  [MainListTab.recruiting]: <OngoingEvent />,
+  [MainListTab.soonend]: <SoonEndEvent />,
 };
 
 export default function MainPage({ state = "main" }: Props) {

--- a/src/Components/Main/Main.tsx
+++ b/src/Components/Main/Main.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import tempBanner from "../Main/Banner/main_banner1.png";
 import tempBannerSmall from "../Main/Banner/main_banner_small.png";
 import ShowEventList from "./ShowEventList";
@@ -32,6 +32,8 @@ export default function MainPage({ state = "main" }: Props) {
   const [listTab, setListTab] = useState<MainListTab>(MainListTab.popular);
 
   const ref = useRef(null);
+  const bannerRef = useRef<any>(null);
+  const bannerRef2 = useRef<any>(null);
 
   useEffect(() => {
     const io = new IntersectionObserver(
@@ -53,15 +55,36 @@ export default function MainPage({ state = "main" }: Props) {
     }
   }, []);
 
+  const resizeBanner = useCallback(() => {
+    const h = window.innerHeight;
+    const MIN_HEADER_HEIGHT = 100;
+
+    if (bannerRef.current)
+      bannerRef.current.style.height = h - MIN_HEADER_HEIGHT + "px";
+    if (bannerRef2.current)
+      bannerRef2.current.style.height = h - MIN_HEADER_HEIGHT + "px";
+  }, []);
+
+  useEffect(() => {
+    resizeBanner();
+    window.addEventListener("resize", resizeBanner);
+
+    return () => {
+      window.removeEventListener("resize", resizeBanner);
+    };
+  }, [resizeBanner]);
+
   return (
     <section>
       <img
         className="w-full h-[600px] bg-white object-contain brightness-95 hidden lg:block"
+        ref={bannerRef}
         src={tempBanner}
         alt="메인 배너 캐러솔"
       />
       <img
         className="w-full h-[600px] bg-white object-cover brightness-95 lg:hidden"
+        ref={bannerRef2}
         src={tempBannerSmall}
         alt="메인 배너 캐러솔"
       />
@@ -85,9 +108,7 @@ export default function MainPage({ state = "main" }: Props) {
               </button>
             ))}
           </div>
-          <div className="flex w-full">
-            {listTabs[listTab]}
-          </div>
+          <div className="flex w-full">{listTabs[listTab]}</div>
         </div>
       </div>
     </section>

--- a/src/Components/Main/OngoingEvent.tsx
+++ b/src/Components/Main/OngoingEvent.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import ShowEventList from "./ShowEventList";
+import { fetchEvents } from "../../Api/Util/EventService";
+
+export default function OngoingEvent() {
+  const { data } = useQuery({
+    queryKey: ["main", "ongoin"],
+    queryFn: () => fetchEvents(0, "최신순", "ongoing"),
+  });
+
+  const eventList = data ? data?.content : [];
+
+  return <ShowEventList title="부스 모집 중" eventList={eventList} />;
+}

--- a/src/Components/Main/RecentEvent.tsx
+++ b/src/Components/Main/RecentEvent.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import ShowEventList from "./ShowEventList";
+import { fetchEvents } from "../../Api/Util/EventService";
+
+export default function RecentEvent() {
+  const { data } = useQuery({
+    queryKey: ["main", "recentevent"],
+    queryFn: () => fetchEvents(0, "최신순", "recruiting"),
+  });
+
+  const eventList = data ? data?.content : [];
+
+  return <ShowEventList title="인기있는 부스" eventList={eventList} />;
+}

--- a/src/Components/Main/ShowEventList.tsx
+++ b/src/Components/Main/ShowEventList.tsx
@@ -1,3 +1,4 @@
+import { Event } from "../../Api/Util/EventService";
 import tempBanner from "../../logo.svg";
 import EventCard from "../Event/List/EventCard";
 import Carousel from "../Util/Carousel";
@@ -12,65 +13,25 @@ export type event = {};
 
 interface Props {
   title: string;
-  eventList: Array<Booth | Event>;
+  eventList: Event[];
 }
 
 export default function ShowEventList({ eventList, title }: Props) {
+  const elementList = eventList.map((event) => (
+    <EventCard
+      endDate={event.recruitEndDate}
+      id={event.id}
+      image={event.mainImageUrl}
+      name={event.name}
+      key={event.id}
+    />
+  ));
   return (
     <div className="flex justify-center">
       <div>
         <Carousel
           className="h-72"
-          list={[
-            <EventCard
-              endDate="123"
-              id={1}
-              image={
-                "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS__0S6K2gnU_PqcvLpFU8SGYGyb7x2ZtoisQ&s"
-              }
-              name="행사"
-            />,
-            <EventCard
-              endDate="123"
-              id={1}
-              image={
-                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/8fXh/image/nZ7e2z99yxb9JzoE0AwQNDN1ft4.jpg"
-              }
-              name="행사"
-            />,
-            <EventCard
-              endDate="123"
-              id={1}
-              image={
-                "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTfvISbILWTN9TaMBJPhWKe9rWc6CwtRJZlWw&s"
-              }
-              name="행사"
-            />,
-            <EventCard
-              endDate="123"
-              id={1}
-              image={
-                "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS__0S6K2gnU_PqcvLpFU8SGYGyb7x2ZtoisQ&s"
-              }
-              name="행사"
-            />,
-            <EventCard
-              endDate="123"
-              id={1}
-              image={
-                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/8fXh/image/nZ7e2z99yxb9JzoE0AwQNDN1ft4.jpg"
-              }
-              name="행사"
-            />,
-            <EventCard
-              endDate="123"
-              id={1}
-              image={
-                "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTfvISbILWTN9TaMBJPhWKe9rWc6CwtRJZlWw&s"
-              }
-              name="행사"
-            />,
-          ]}
+          list={[...elementList]}
           dot={false}
           button={false}
         />

--- a/src/Components/Main/SoonEndEvent.tsx
+++ b/src/Components/Main/SoonEndEvent.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import ShowEventList from "./ShowEventList";
+import { fetchEvents } from "../../Api/Util/EventService";
+
+export default function SoonEndEvent() {
+  const { data } = useQuery({
+    queryKey: ["main", "soonEnd"],
+    queryFn: () => fetchEvents(0, "오래된순", "ongoing"),
+  });
+
+  const eventList = data ? data?.content : [];
+
+  return <ShowEventList title="종료 예정인 행사" eventList={eventList} />;
+}

--- a/src/Components/MyPage/MyPage.tsx
+++ b/src/Components/MyPage/MyPage.tsx
@@ -49,11 +49,13 @@ export default function MyPage() {
     <RequestLayout header="마이페이지">
       <section className="flex flex-col w-full h-full p-2">
         <div className="flex">
-          <div className="flex flex-col gap-2 w-32 border-r py-4">
+          <div className="flex flex-col w-32 border-r">
             {Object.keys(MENUS).map((sidebar) => (
               <button
                 onClick={() => onClickSideBar(sidebar)}
-                className={currentSideMenu === sidebar ? "font-bold" : ""}
+                className={`${
+                  currentSideMenu === sidebar ? "font-bold" : ""
+                } border-b py-6 hover:shadow-sm hover:bg-blue-50/20`}
               >
                 {MENUS[sidebar].menu}
               </button>

--- a/src/Components/NoticeCard.tsx
+++ b/src/Components/NoticeCard.tsx
@@ -9,16 +9,18 @@ export default function NoticeCard({ notice, alignType = "column" }: Props) {
 
   if (alignType === "row") {
     return (
-      <div className={`flex flex-col p-2 pb-4 border-b-2 last:border-none`}>
+      <div className={`flex flex-col p-2 pb-4 border-b last:border-none`}>
         <h2 className="font-semibold text-sm py-2">
           {type === "EVENT" ? "💛이벤트" : "📢공지"}
         </h2>
         <div className={`flex flex-row gap-4`}>
-          <img
-            src={imageUrl}
-            alt="noticeImage"
-            className="h-24 aspect-square shadow-inner border object-contain rounded-md"
-          />
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt="noticeImage"
+              className="h-24 aspect-square shadow-inner border object-contain rounded-md"
+            />
+          )}
           <div className="flex flex-col gap-1">
             <div className="font-bold">{title}</div>
             <div className="line-clamp-4">{content}</div>
@@ -30,18 +32,20 @@ export default function NoticeCard({ notice, alignType = "column" }: Props) {
 
   return (
     <div
-      className={`flex justify-center p-2 pb-4 border-b-2 last:border-none w-full`}
+      className={`flex justify-center p-2 pb-4 border-b last:border-none w-full`}
     >
       <div className={`flex flex-col gap-1 w-full max-w-[80%]`}>
         <h2 className="font-bold py-2">
           {type === "EVENT" ? "💛이벤트" : "📢공지"}
         </h2>
         <div className="flex flex-col w-full gap-2">
-          <img
-            src={imageUrl}
-            alt="noticeImage"
-            className="h-52 aspect-video max-w-80 shadow-inner border object-contain rounded-md mx-auto"
-          />
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt="noticeImage"
+              className="h-52 aspect-video max-w-80 shadow-inner border object-contain rounded-md mx-auto"
+            />
+          )}
           <div className="font-bold">{title}</div>
           <div className="line-clamp-4">{content}</div>
         </div>


### PR DESCRIPTION
**DONE**
1. 로그인 안했을 때, 행사 상세에서 "부스 신청, 행사 관리" 버튼 안보이게 수정
2. 진행 중 행사인데도 신청 버튼이 보이는 부분 수정
7. 행사 등록에서 칸에서 엔터 누르면 무조건 지역 검색 모달창이 떠서 수정해야함.
9. 공지사항에서 이미지 등록 안할 시 이미지 부분 아예 빼버리기
11. 처음 페이지 켰을 때 메인페이지 NavBar랑 배너로 꽉 차게 구성 -> 스크롤 내리면 아래 항목들 보이도록~!!
3. 메인 페이지 아래 정보 목록에 "인기있는 부스"를 제외하고 나머지는 있는 api를 활용해서 데이터 패칭 진행
10. 행사 상세 페이지 위아래 공백 주기(NavBar랑 Footer랑 너무 붙어있음)
8. 마이페이지 항목(탭)들 간격 넓히기
5. 관리자 페이지 정렬은 신청일로 잘 되어있는데, 승인 반려 버튼으로 정렬하는 부분 구현 안되있음


**BLOCKED, TODO**
4. 마이페이지 API 연동 : 프로필(이메일, 닉네임) -> api 제작 예정 / 구매내역 -> 구매내역은 삭제
6. 행사 상세에서 부스 목록 api 연동 -> api 제작 예정


**이해가 잘 안됨**
12. 행사, 부스 상세 페이지 수정 시 행사 관리, 부스 관리 버튼 누르면 마이페이지처럼 탭을 나눠서 수정페이지 만들기
(행사 관리 : 승인/반려 탭, 행사 상세 수정 탭) (부스 관리 : 부스 상세 수정 탭)